### PR TITLE
Stop loading the whole genome into RAM (OOM on large assemblies)

### DIFF
--- a/dante_tir.py
+++ b/dante_tir.py
@@ -136,14 +136,14 @@ def main():
         dt.save_grouping_info(aa_sequence_groups, aa_mmseqs2_output_dirs)
         print(" done")
 
-    # Read FASTA file with genome assembly
-    genome = dt.fasta_to_dict(args.fasta)
-
     # extract sequence for each protein domain including upstream and downstream
     # use strand information to extract upstream and downstream, if strand is
     # negative, then upstream is downstream and vice versa, for negative
-    # reverse complement the sequence
-    downstream_seq, upstream_seq, coords = dt.extract_flanking_regions(genome,
+    # reverse complement the sequence.
+    # The genome is streamed one sequence at a time inside extract_flanking_regions
+    # (not loaded whole via fasta_to_dict) to avoid holding the entire assembly in
+    # memory, which OOMs on large genomes.
+    downstream_seq, upstream_seq, coords = dt.extract_flanking_regions(args.fasta,
                                                                        tir_domains)
     # export downstream and upstream sequences to files, one file for each upstream,
     # downstream and classification

--- a/dt_utils.py
+++ b/dt_utils.py
@@ -721,7 +721,29 @@ def save_gff3_dict_to_file(gff3_dict_list: Dict[str, List[Gff3Feature]], gff3_fi
             for gff in gff3_dict_list[cls]:
                 f.write(str(gff))
 
-def extract_flanking_regions(genome: Dict[str, str],
+def fasta_record_generator(fasta_file: str):
+    """Yield ``(name, sequence)`` one FASTA record at a time.
+
+    Only the current record is held in memory, so peak usage is the largest
+    single sequence rather than the whole assembly. ``name`` is the header up to
+    the first whitespace (matching :func:`fasta_to_dict`).
+    """
+    name = None
+    chunks: List[str] = []
+    with open(fasta_file, 'r') as fh:
+        for line in fh:
+            if line.startswith(">"):
+                if name is not None:
+                    yield name, "".join(chunks)
+                name = line[1:].split()[0]
+                chunks = []
+            else:
+                chunks.append(line.strip())
+        if name is not None:
+            yield name, "".join(chunks)
+
+
+def extract_flanking_regions(fasta_file: str,
                              tir_domains: Dict[str, List[Gff3Feature]]
                              ) -> Tuple[
     Dict[str, Dict[int, str]],
@@ -731,62 +753,81 @@ def extract_flanking_regions(genome: Dict[str, str],
 
     """
     Extract flanking regions of TIR domains
-    :param genome:
+
+    :param fasta_file: path to the genome FASTA. It is streamed one sequence at a
+        time (not loaded whole via fasta_to_dict), so peak memory is the largest
+        single sequence, not the whole assembly — the latter OOMs on large
+        genomes while only ~6 kb flanks per domain are ever needed.
     :param tir_domains:
     :return: downstream and upstream sequences for each TIR domain
     :return: table with coordinates of donwstream and upstream sequences relative genome
 
     If sequence is on the negative strand,  sequences are reverse complemented
     """
-    upstream_seq = {}
-    downstream_seq = {}
-    coords = {}
+    upstream_seq: Dict[str, Dict[str, str]] = {cls: {} for cls in tir_domains}
+    downstream_seq: Dict[str, Dict[str, str]] = {cls: {} for cls in tir_domains}
+    coords: Dict[str, Dict[str, List[int]]] = {cls: {} for cls in tir_domains}
     offset = 6000
     offset2 = 300
+    # Group domains by seqid so each streamed sequence is processed in one pass.
+    domains_by_seqid: Dict[str, List[Tuple[str, Gff3Feature]]] = {}
     for cls in tir_domains:
-        coords[cls] = {}
-        upstream_seq[cls] = {}
-        downstream_seq[cls] = {}
         for gff in tir_domains[cls]:
+            domains_by_seqid.setdefault(gff.seqid, []).append((cls, gff))
+    # (cls, ID) -> (upstream, downstream_rc, coord); assembled in original order below.
+    computed: Dict[Tuple[str, str], Tuple[str, str, List[int]]] = {}
+    for seqid, seq in fasta_record_generator(fasta_file):
+        domains = domains_by_seqid.get(seqid)
+        if not domains:
+            continue
+        for cls, gff in domains:
             if gff.strand == '+':
                 u_s = max(0, gff.start - offset)
-                upstream = genome[gff.seqid][u_s:gff.start + offset2]
-                downstream = genome[gff.seqid][gff.end - offset2:gff.end + offset]
+                upstream = seq[u_s:gff.start + offset2]
+                downstream = seq[gff.end - offset2:gff.end + offset]
                 # coordinates could be out of range - adjust to sequence length
                 offset_u_adjusted = len(upstream) - offset2
                 offset_d_adjusted = len(downstream) - offset2
-                coords[cls][gff.attributes_dict['ID']] = [
+                coord = [
                     gff.seqid,
                     gff.start - offset_u_adjusted,
                     gff.start + offset2,
                     gff.end - offset2,
                     gff.end + offset_d_adjusted,
                     gff.strand]
-
             else:
                 d_s = max(0, gff.start - offset)
                 upstream = reverse_complement(
-                        genome[gff.seqid][gff.end - offset2:gff.end + offset]
+                        seq[gff.end - offset2:gff.end + offset]
                         )
                 downstream = reverse_complement(
-                        genome[gff.seqid][d_s:gff.start + offset2]
+                        seq[d_s:gff.start + offset2]
                         )
                 # coordinates could be out of range - adjust to sequence length
                 offset_u_adjusted = len(upstream) - offset2
                 offset_d_adjusted = len(downstream) - offset2
-
-                coords[cls][gff.attributes_dict['ID']] = [
+                coord = [
                     gff.seqid,
                     gff.end - offset2,
                     gff.end + offset_u_adjusted,
                     gff.start - offset_d_adjusted,
                     gff.start + offset2,
                     gff.strand]
-
+            # to make analysis easier, downstream sequence is reverse complemented
+            # - insertion site will be on 5' end
+            computed[(cls, gff.attributes_dict['ID'])] = (
+                upstream, reverse_complement(downstream), coord)
+    # Assemble in the original (class, domain) order for output stability.
+    for cls in tir_domains:
+        for gff in tir_domains[cls]:
             ID = gff.attributes_dict['ID']
+            entry = computed.get((cls, ID))
+            if entry is None:
+                continue
+            upstream, downstream_rc, coord = entry
             upstream_seq[cls][ID] = upstream
-            # to make analysis easier, downstream sequence is reverse complemented - insertions site will be on 5' end
-            downstream_seq[cls][ID] = reverse_complement(downstream)
+            downstream_seq[cls][ID] = downstream_rc
+            coords[cls][ID] = coord
 
     return downstream_seq, upstream_seq, coords
 

--- a/tests.sh
+++ b/tests.sh
@@ -25,16 +25,18 @@ if command -v conda >/dev/null 2>&1 && [ -z "${CONDA_DEFAULT_ENV:-}" ]; then
 fi
 
 case "$LEVEL" in
+  unit)  bash "$ROOT/tests/unit.sh"  ;;
   smoke) bash "$ROOT/tests/smoke.sh" ;;
   short) bash "$ROOT/tests/short.sh" ;;
   long)  bash "$ROOT/tests/long.sh"  ;;
   all)
+    bash "$ROOT/tests/unit.sh"
     bash "$ROOT/tests/smoke.sh"
     bash "$ROOT/tests/short.sh"
     bash "$ROOT/tests/long.sh"
     ;;
   *)
-    echo "usage: $0 {smoke|short|long|all|<NCPU>}" >&2
+    echo "usage: $0 {unit|smoke|short|long|all|<NCPU>}" >&2
     exit 2
     ;;
 esac

--- a/tests/test_extract_flanking_regions.py
+++ b/tests/test_extract_flanking_regions.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Equivalence test for the memory-frugal extract_flanking_regions rewrite.
+
+extract_flanking_regions used to take a whole-genome dict from fasta_to_dict
+(~genome_bp of RAM, OOM on large assemblies). It now takes the FASTA path and
+streams one sequence at a time (peak = largest single sequence). This test
+proves the streaming version returns EXACTLY the same upstream/downstream/coords
+as the original dict-based logic, across:
+  - both strands,
+  - windows clamped at the sequence start (start < offset) and end
+    (end + offset > length),
+  - a line-wrapped multi-sequence FASTA,
+  - domains on more than one sequence.
+
+Run: python3 tests/test_extract_flanking_regions.py
+"""
+import os
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+import dt_utils as dt  # noqa: E402
+
+
+def reference_extract(genome, tir_domains):
+    """Verbatim copy of the ORIGINAL dict-based implementation (the reference)."""
+    upstream_seq, downstream_seq, coords = {}, {}, {}
+    offset, offset2 = 6000, 300
+    for cls in tir_domains:
+        coords[cls], upstream_seq[cls], downstream_seq[cls] = {}, {}, {}
+        for gff in tir_domains[cls]:
+            if gff.strand == '+':
+                u_s = max(0, gff.start - offset)
+                upstream = genome[gff.seqid][u_s:gff.start + offset2]
+                downstream = genome[gff.seqid][gff.end - offset2:gff.end + offset]
+                offset_u_adjusted = len(upstream) - offset2
+                offset_d_adjusted = len(downstream) - offset2
+                coords[cls][gff.attributes_dict['ID']] = [
+                    gff.seqid, gff.start - offset_u_adjusted, gff.start + offset2,
+                    gff.end - offset2, gff.end + offset_d_adjusted, gff.strand]
+            else:
+                d_s = max(0, gff.start - offset)
+                upstream = dt.reverse_complement(
+                    genome[gff.seqid][gff.end - offset2:gff.end + offset])
+                downstream = dt.reverse_complement(
+                    genome[gff.seqid][d_s:gff.start + offset2])
+                offset_u_adjusted = len(upstream) - offset2
+                offset_d_adjusted = len(downstream) - offset2
+                coords[cls][gff.attributes_dict['ID']] = [
+                    gff.seqid, gff.end - offset2, gff.end + offset_u_adjusted,
+                    gff.start - offset_d_adjusted, gff.start + offset2, gff.strand]
+            ID = gff.attributes_dict['ID']
+            upstream_seq[cls][ID] = upstream
+            downstream_seq[cls][ID] = dt.reverse_complement(downstream)
+    return downstream_seq, upstream_seq, coords
+
+
+def make_seq(n, salt=0):
+    return "".join("ACGT"[(i * 7 + salt) % 4] for i in range(n))
+
+
+def write_wrapped_fasta(path, seqs, width=70):
+    with open(path, "w") as fh:
+        for name, seq in seqs:
+            fh.write(">%s some description here\n" % name)
+            for i in range(0, len(seq), width):
+                fh.write(seq[i:i + width] + "\n")
+
+
+def gff(seqid, start, end, strand, fid, cls):
+    line = "\t".join([seqid, "dante_tir", "tir", str(start), str(end),
+                      ".", strand, ".", "ID=%s;Class=%s" % (fid, cls)])
+    return dt.Gff3Feature(line)
+
+
+def main():
+    seqs = [("chr1", make_seq(9000, 1)), ("chr2", make_seq(1000, 2))]
+    tmp = tempfile.mkdtemp(prefix="tir_flank_test_")
+    fasta = os.path.join(tmp, "genome.fasta")
+    write_wrapped_fasta(fasta, seqs)
+
+    tir_domains = {
+        "hAT": [
+            gff("chr1", 7000, 7400, "+", "d_mid_plus", "Class_II|Subclass_1|TIR|hAT"),
+            gff("chr1", 500, 900, "-", "d_mid_minus", "Class_II|Subclass_1|TIR|hAT"),
+            gff("chr1", 100, 400, "+", "d_start_clamp", "Class_II|Subclass_1|TIR|hAT"),
+        ],
+        "MuDR_Mutator": [
+            gff("chr2", 600, 950, "-", "d_end_clamp", "Class_II|Subclass_1|TIR|MuDR_Mutator"),
+            gff("chr2", 300, 500, "+", "d_chr2_plus", "Class_II|Subclass_1|TIR|MuDR_Mutator"),
+        ],
+    }
+
+    genome = dt.fasta_to_dict(fasta)
+    ref_down, ref_up, ref_coords = reference_extract(genome, tir_domains)
+    new_down, new_up, new_coords = dt.extract_flanking_regions(fasta, tir_domains)
+
+    assert new_down == ref_down, "downstream sequences differ from reference"
+    assert new_up == ref_up, "upstream sequences differ from reference"
+    assert new_coords == ref_coords, "coords differ from reference"
+
+    n = sum(len(v) for v in ref_up.values())
+    print("  extract_flanking_regions: %d domains, streaming output == dict output" % n)
+
+    # sanity: the generator reconstructs wrapped sequences exactly
+    got = dict(dt.fasta_record_generator(fasta))
+    for name, seq in seqs:
+        assert got[name] == seq, "fasta_record_generator mangled %s" % name
+    print("  fasta_record_generator: wrapped multi-seq FASTA reconstructed exactly")
+    print("test_extract_flanking_regions: PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit.sh
+++ b/tests/unit.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# tests/unit.sh — fast pure-python unit tests (no external tools / data).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "=== unit: extract_flanking_regions streaming == dict (OOM fix) ==="
+python3 "$ROOT/tests/test_extract_flanking_regions.py"
+
+echo "unit tests OK"


### PR DESCRIPTION
<!-- repo: kavonrtep/dante_tir   base: main   head: fix/large-genome-scaling -->

## Summary

`extract_flanking_regions` takes a **whole-genome dict** from `fasta_to_dict`
(`dante_tir.py` → `genome = dt.fasta_to_dict(args.fasta)`), which materialises the
entire assembly in RAM (~90–180 GB peak for a 90 Gbp genome, list-of-lines +
joined string) — an OOM before any TIR work — even though only ~6 kb flanks
around each TPase domain are ever used.

This PR makes `extract_flanking_regions` take the FASTA **path** and stream one
sequence at a time, so peak memory is the largest single sequence (a few GB), not
the whole assembly.

## Change

- New `fasta_record_generator(fasta_file)` — yields `(name, sequence)` one record
  at a time (only the current record is held in memory).
- `extract_flanking_regions(fasta_file, tir_domains)` groups domains by seqid,
  processes each streamed sequence once, and assembles the result in the original
  `(class, domain)` order with the **same** strand / reverse-complement logic and
  window-clamping as before.
- Caller updated: `genome = dt.fasta_to_dict(args.fasta)` is removed and the path
  is passed through. (The other `fasta_to_dict` callers operate on already-split
  small files and are untouched.)

Output is **byte-identical** to the previous implementation.

## Testing

- `tests/test_extract_flanking_regions.py` (added as a `unit` level via
  `tests/unit.sh` + `tests.sh`): asserts the streaming output equals the original
  dict-based logic across both strands, start/end window clamping, a line-wrapped
  multi-sequence FASTA, and domains on more than one sequence.
- End-to-end: the `short` test detects the same TIRs as before; an A/B against the
  released version produced identical `DANTE_TIR_final.gff3`.

## Not included (follow-up): Round-1 parallelisation is blocked by Rbeast

Round 1 (`process_region_files` → `find_switch_point` → `Rbeast::beast`) is
single-threaded and the heaviest CPU stage. I implemented an `mclapply`
parallelisation of it, but it **silently changed detection results** at
`threads > 1` (on the `short` test: **14 → 10** TIR records, no error). It is
**not** RNG-related (`mc.set.seed = FALSE` → still 10) and **not** OpenMP
(`OMP_NUM_THREADS=1` → still 10); `-c 1` matched stock exactly. `find_switch_point`
passes a fixed `mcmc.seed`, so each `beast()` call should be deterministic, yet
concurrent forked execution makes some return `NA` — pointing to shared
global/temp state inside Rbeast that is unsafe under `fork`. A naive `mclapply`
is therefore a silent-data-loss bug and was **reverted**; a safe parallelisation
needs either an Rbeast fork-safety fix or a process-isolated backend (PSOCK
`parLapply`) plus a guard that fails loudly if a worker returns fewer detections
than serial. This PR is the memory fix only, which is independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)